### PR TITLE
Load Objectron Sequence as `torch.utils.data.IterableDataset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # ai604-video-object-pose
+
 Video Object Pose estimation project for KAIST 2021SP AI604 : Computer Vision
+
+## TFRecord Parsing
+
+Requires a modified version of the `tfrecord` package to handle the following list of complications:
+
+* Loading from GCS (Google Cloud Storage) bucket
+* Loading a `SequenceExample`
+* Loading from shard(s)
+
+One way to install the package would be the following:
+
+```bash
+pip3 install git+https://github.com/yycho0108/tfrecord.git@gcs-seq
+```
+
+For further details, visit [yycho0108/tfrecord](https://github.com/yycho0108/tfrecord.git) instead.

--- a/objectron_dataset.py
+++ b/objectron_dataset.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+
+__all__ = ['Objectron']
+
+import os
+import sys
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple, Dict
+from PIL import Image
+import numpy as np
+import pickle
+
+# torch+torchvision
+import torch as th
+import torch.nn as nn
+import torchvision.io as thio
+from torchvision import transforms
+
+from tfrecord.reader import sequence_loader
+from google.cloud import storage
+
+
+def _glob_objectron(bucket_name: str, prefix: str):
+    client = storage.Client.create_anonymous_client()
+    blobs = client.list_blobs(bucket_name, prefix=prefix)
+    return [blob.name for blob in blobs]
+
+
+class Objectron(th.utils.data.IterableDataset):
+    """
+    Objectron dataset (currently configured for loading sequences only).
+    """
+
+    @dataclass
+    class Settings:
+        bucket_name: str = 'objectron'
+        classes: Tuple[str] = (
+            'bike',
+            'book',
+            'bottle',
+            'camera',
+            'cereal_box',
+            'chair',
+            'cup',
+            'laptop',
+            'shoe')
+        train: bool = True
+        shuffle: bool = True
+        # NOTE(ycho): Refer to objectron/schema/features.py
+        context: List[str] = ('count', 'sequence_id')
+        # NOTE(ycho): Refer to objectron/schema/features.py
+        features: List[str] = (
+            'instance_num',
+            'image/width',
+            'image/height',
+            'image/channels',
+            'image/encoded',
+            'object/name',
+            'object/translation',
+            'object/orientation',
+            'object/scale',
+            'camera/intrinsics',
+            'camera/extrinsics',
+            'camera/projection',
+            'camera/view',
+        )
+        cache_dir = '~/.cache/ai604/'
+
+    def __init__(self, opts: Settings, transform=None):
+        self.opts = opts
+        self.shards = self._get_shards()
+        self.xfm = transform
+
+        self._index_map = {c: i for i, c in enumerate(self.opts.classes)}
+        self._class_map = {i: c for i, c in enumerate(self.opts.classes)}
+
+    def _index_from_class(self, cls: str):
+        return self._index_map[cls]
+
+    def _class_from_index(self, idx: str):
+        return self._class_map[idx]
+
+    def _get_shards(self):
+        """ return list of shards, potentially memoized for efficiency """
+        prefix = 'train' if self.opts.train else 'test'
+        shards_cache = F'{self.opts.cache_dir}/{prefix}-shards.pkl'
+
+        shards_path = Path(shards_cache).expanduser()
+        if not shards_path.exists():
+            shards_path.parent.mkdir(parents=True, exist_ok=True)
+            shards = self._glob()
+            with open(str(shards_path), 'wb') as f:
+                pickle.dump(shards, f)
+        else:
+            with open(str(shards_path), 'rb') as f:
+                shards = pickle.load(f)
+
+        if self.opts.shuffle:
+            np.random.shuffle(shards)
+        return shards
+
+    def _glob(self) -> List[str]:
+        train_type = 'train' if self.opts.train else 'test'
+        shards = []
+
+        # Aggregate class shards
+        for cls in self.opts.classes:
+            prefix = F'v1/sequences/{cls}/{cls}_{train_type}'
+            cls_shards = _glob_objectron(self.opts.bucket_name, prefix)
+            shards.extend(cls_shards)
+        return shards
+
+    def __iter__(self):
+        # Deal with parallelism...
+        # NOTE(ycho): harder to assume uncorrelated inputs
+        # without multiple workers loading from different shards
+        # on a single batch.
+        worker_info = th.utils.data.get_worker_info()
+        if worker_info is None:
+            i0 = 0
+            i1 = len(self.shards)
+        else:
+            n = int(np.ceil(len(self.shards) / float(worker_info.num_workers)))
+            i0 = worker_info.id * n
+            i1 = min(len(self.shards), i0 + n)
+
+        # Contiguous block slice among shards
+        for shard in self.shards[i0:i1]:
+            # Resolve shard name relative to bucket.
+            shard_name = F'gs://{self.opts.bucket_name}/{shard}'
+
+            # Parse class name from the shard name.
+            # This is to avoid awkward string conversion later.
+            class_name = shard.split('/')[-2]
+            class_index = self._index_from_class(class_name)
+
+            # NOTE(ycho): tfrr doesn't work due to
+            # GCS + SequenceExample. Therefore, we use
+            # a custom fork of `tfrecord` package.
+            # TODO(ycho): Protection on network error cases
+            # Which will inevitably arise during long training
+            reader = sequence_loader(
+                shard_name, None, self.opts.context,
+                self.opts.features, None, True)
+
+            # Wonder how many samples there are per-shard??
+            for i, (context, features) in enumerate(reader):
+                # Replace object/name to object/class here.
+                names = features.pop('object/name')
+
+                # NOTE(ycho): Instead of trying to parse bytes->str->index,
+                # Just rewrite object class with the known class index.
+                # TODO(ycho): Watch out for heterogeneous frames, if any.
+                # FIXME(ycho): ^^ quite likely?
+                classes = th.as_tensor(
+                    [class_index for c in names],
+                    dtype=th.int32)
+                features['object/class'] = classes
+
+                out = (context, features)
+
+                # Apply optional transform on the data.
+                # NOTE(ycho): This step is mandatory if we'd like to convert the dataset
+                # to fixed-length representation.
+                if self.xfm is not None:
+                    out = self.xfm(out)
+                yield out
+
+
+class DecodeImage:
+    """
+    Decode serialized image bytes, and resize them to a fixed size.
+    FIXME(ycho): Modify camera intrinsics according to the resize transform.
+    """
+
+    def __init__(self, size: Tuple[int, int], in_place: bool = True):
+        self.size = size
+        self.in_place = in_place
+        self.resize = transforms.Resize(self.size)
+
+    def __call__(self, inputs: Tuple[dict, dict]):
+        if inputs is None:
+            return None
+        context, features = inputs
+
+        # NOTE(ycho): Shallow copy but pedantically safer
+        if not self.in_place:
+            features = features.copy()
+
+        # Replace `image/encoded` with `image`
+        features['image'] = th.stack([
+            self.resize(thio.decode_image(th.from_numpy(img_bytes)))
+            for img_bytes in features['image/encoded']], dim=0)
+
+        del features['image/encoded']
+
+        # Dimension features are no longer valid.
+        # We can also rewrite them, but this information is already
+        # implicitly included in features["image"].
+        del features['image/width']
+        del features['image/height']
+
+        return (context, features)
+
+
+class ParseFixedLength:
+    """
+    Convert variable-length sequence to fixed-length representation.
+    Intended to be used immediately after the raw output from `Objectron`.
+
+    FIXME(ycho): Isn't it a bit wasteful to slice up a full video once
+    and discard the reset?? Discuss strategies on overcoming correlated-samples issue
+    """
+    class Settings:
+        seq_len: int = 8  # length of sub-sequence to extract
+        max_num_inst: int = 4  # max number of instances in the frame
+        stride: int = 4  # number of intermediate frames to skip
+
+        # NOTE(ycho): Variable-length fields to apply padding for
+        # `max_num_inst` ... needed for collating to batch
+        pad_keys: Tuple[str, ...] = (
+            'object/translation', 'object/orientation', 'object/scale')
+
+    def __init__(self, opts: Settings):
+        self.opts = opts
+
+    def __call__(
+            self, inputs: Tuple[Dict[str, th.Tensor],
+                                Dict[str, th.Tensor]]):
+        if inputs is None:
+            return None
+        context, features = inputs
+
+        # Reject data with less than `seq_len` frames.
+        # NOTE(ycho): Unsqueeze `count` which is a scalar.
+        n = context['count'][0]
+        if n < self.opts.seq_len:
+            return None
+
+        # Extract a slice of length `seq_len` from the sequence.
+        max_stride = n // self.opts.seq_len
+        stride = min(max_stride, self.opts.stride)
+        strided_len = stride * self.opts.seq_len
+
+        i0 = np.random.randint(0, n - strided_len + 1)
+        i1 = i0 + strided_len
+
+        # FIXME(ycho):
+        # sequence_id is currently a bytes list instead of `string`.
+        # This makes it somewhat clunky to collate, so we'll drop this field
+        # for now.
+        # TODO(ycho): Consider adding `stride` to `new_ctx`
+        new_ctx = dict(count=self.opts.seq_len)
+        new_feat = {k: v[i0:i1:stride] for (k, v) in features.items()}
+
+        # Some property are variable-length, since they are dependent on `instance_num`.
+        # Pad the sequences to account for this.
+        for key in self.opts.pad_keys:
+            num_inst = new_feat['instance_num']
+            x = new_feat[key]
+
+            # single reference instance
+            ref = th.as_tensor(x[0])
+            # Compute single-feature dimension
+            # TODO(ycho): consider assert for ref.shape[0] % num_inst[0] == 0
+            dim = int(ref.shape[0] // num_inst[0])
+
+            x_pad = ref.new_empty(
+                (self.opts.seq_len, dim * self.opts.max_num_inst))
+            if np.all(num_inst == num_inst[0]):
+                # TODO(ycho): ensure this still works if
+                # `instance_num` > `max_num_inst`
+                m = min(dim * self.opts.max_num_inst, ref.shape[0])
+                x_pad[:, :m] = th.as_tensor(x)[:, :m]
+            else:
+                max_n = min(self.opts.max_num_inst, num_ints)
+                for i, n in enumerate(max_n):
+                    x_pad[i, :n * dim] = th.as_tensor(x[i])
+            new_feat[key] = x_pad
+
+        return (new_ctx, new_feat)
+
+
+def _skip_none(batch):
+    """ Wrapper around default_collate() for skipping `None`. """
+    batch = [x for x in batch if (x is not None)]
+    return th.utils.data.dataloader.default_collate(batch)
+
+
+def main():
+    opts = Objectron.Settings()
+    xfm = transforms.Compose([
+        DecodeImage(size=(480, 640)),
+        ParseFixedLength(ParseFixedLength.Settings()),
+    ])
+    dataset = Objectron(opts, xfm)
+    loader = th.utils.data.DataLoader(
+        dataset, batch_size=2, num_workers=0,
+        collate_fn=_skip_none)
+
+    for data in loader:
+        # print(data)
+        break
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+--find-links https://download.pytorch.org/whl/torch_stable.html
+
+numpy==1.19.0
+dataclasses==0.8
+google-cloud-core==1.6.0
+google-cloud-storage==1.37.0
+googleapis-common-protos==1.53.0
+protobuf==3.15.6
+git+git://github.com/yycho0108/tfrecord.git@gcs-seq#egg=tfrecord
+torch==1.7.1+cu101
+# torch-xla is a bit of a mess. configure as needed on your machine.
+https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.7-cp36-cp36m-linux_x86_64.whl
+torchvision==0.8.2+cu101

--- a/show_sequence.ipynb
+++ b/show_sequence.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports for core lib\n",
+    "import torch as th\n",
+    "from torchvision import transforms\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports for visualization\n",
+    "import cv2\n",
+    "from matplotlib import pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports for dataset\n",
+    "from objectron_dataset import Objectron, DecodeImage, ParseFixedLength, _skip_none"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configure experiment\n",
+    "batch_size = 2\n",
+    "image_shape = (480,640)\n",
+    "sequence_length = 8\n",
+    "num_workers = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configure options, transforms\n",
+    "# instantiate dataset and loader\n",
+    "opts = Objectron.Settings()\n",
+    "xfm = transforms.Compose([\n",
+    "    DecodeImage(size=image_shape),\n",
+    "    ParseFixedLength(ParseFixedLength.Settings()),\n",
+    "])\n",
+    "dataset = Objectron(opts, xfm)\n",
+    "loader = th.utils.data.DataLoader(\n",
+    "    dataset, batch_size=batch_size, num_workers=num_workers,\n",
+    "    collate_fn=_skip_none)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get single data from loader. Takes a VERY long time.\n",
+    "data = next(iter(loader))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contexts, features = data\n",
+    "features['object/class']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_objects_with_pose(feat):\n",
+    "    image = feat['image'].cpu().numpy()\n",
+    "    _, h, w = image.shape\n",
+    "    \n",
+    "    # NOTE(ycho): copy required due to OpenCV restrictions (contiguous)\n",
+    "    image = image.transpose(1, 2, 0)\n",
+    "    image = image.copy()\n",
+    "    \n",
+    "    # 3D Bounding-box vertices.\n",
+    "    box_verts = [\n",
+    "        (-0.5,-0.5,-0.5),\n",
+    "        (-0.5,-0.5,+0.5),\n",
+    "        (-0.5,+0.5,-0.5),\n",
+    "        (-0.5,+0.5,+0.5),\n",
+    "        (+0.5,-0.5,-0.5),\n",
+    "        (+0.5,-0.5,+0.5),\n",
+    "        (+0.5,+0.5,-0.5),\n",
+    "        (+0.5,+0.5,+0.5),\n",
+    "    ]\n",
+    "    box_verts = np.asarray(box_verts, dtype=np.float32)\n",
+    "    \n",
+    "    num_inst = feat['instance_num'][0]\n",
+    "    for i in range(num_inst):\n",
+    "        irxn = feat['object/orientation'][i*9:(i+1)*9]\n",
+    "        itxn = feat['object/translation'][i*3:(i+1)*3]\n",
+    "        iscale = feat['object/scale'][i*3:(i+1)*3]\n",
+    "        \n",
+    "        T_scale = np.diag(np.r_[iscale.cpu().numpy(), 1.0])\n",
+    "        # BBOX3D transform\n",
+    "        T_box = np.eye(4)\n",
+    "        T_box[:3,:3] = irxn.reshape(3,3).cpu().numpy()\n",
+    "        T_box[:3,-1] = itxn.cpu().numpy()\n",
+    "        \n",
+    "        # camera transforms\n",
+    "        T_p = feat['camera/projection'].cpu().numpy().reshape(4,4)\n",
+    "#         T_v = feat['camera/view'].cpu().numpy().reshape(4,4)\n",
+    "        \n",
+    "        # Compose all transforms\n",
+    "        # NOTE(ycho): Looks like `camera/view` is not needed.\n",
+    "        # Perhaps it's been fused into object/{translation,orientation}.\n",
+    "        T = T_p @ T_box @ T_scale\n",
+    "        \n",
+    "        # apply transform\n",
+    "        v = box_verts @ T[:3,:3].T + T[:3,-1]\n",
+    "        # project\n",
+    "        v[..., :-1] /= v[..., -1:]\n",
+    "        \n",
+    "        # TODO(ycho): Consider also incorporating\n",
+    "        # NDC transform into the above composed xfm.\n",
+    "        v[...,0] = (1 + v[...,0]) * (0.5 * h)\n",
+    "        v[...,1] = (1 + v[...,1]) * (0.5 * w)\n",
+    "        y, x = v[...,0], v[..., 1]\n",
+    "        \n",
+    "        for (px, py) in zip(x,y):\n",
+    "            cv2.circle(image, (int(px),int(py)), 16, (0,0,255), -1)\n",
+    "    return image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# TODO(ycho): Deal with cases where collation results < batch_size samples\n",
+    "# due to short sequence or network error. For now, no such error checking is performed.\n",
+    "fig, axs = plt.subplots(batch_size, sequence_length, figsize=(12,8), dpi= 200)\n",
+    "for i_batch in range(batch_size):\n",
+    "    for i_seq in range(sequence_length):\n",
+    "#         print({k:v.shape for (k,v) in features.items()})\n",
+    "        ctx = {k : v[i_batch] for (k,v) in contexts.items()}\n",
+    "        feat = {k : v[i_batch,i_seq] for (k,v) in features.items()}\n",
+    "        image = draw_objects_with_pose(feat)\n",
+    "        \n",
+    "        axs[i_batch,i_seq].imshow(image)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "th_env",
+   "language": "python",
+   "name": "th_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
# Summary

This PR adds a capability to read in `TFRecord` shards of form `gs://objectron/v1/sequences/*/*_train` from a `GCS`(Google Cloud Storage) bucket into a `torch.utils.data.IterableDataset`. In order to achieve this feature, we drop the use of the existing `TFRecordReader` from `torch_xla` since it cannot load `tf.train.SequenceExample`. Instead, we incorporate the `tfrecord` package and upgrade the package to be able to interface with `GCS` inputs.

Specifically, the list of features are as follows:
* globbing list of shards from gs bucket
* memoization for list of shards
* class index mapping
* shard loading with support for parallelism
* image decoder transformation
* fixed-length transformation (for collation)
* support for dataset collation (batching)
* strided frame loading to reduce redundant data
* added example bbox visualization notebook

# Results

![download](https://user-images.githubusercontent.com/14655667/113618162-3d229400-9692-11eb-9a35-ed6634013236.png)

![download (1)](https://user-images.githubusercontent.com/14655667/113618327-7bb84e80-9692-11eb-82d2-953aad1855fd.png)

# Discussion
* The current dataset loader is very slow. It's possible that since each sequence is rather large, it takes a while for the data to be loaded.
* We are not very careful with the shard-loading strategy: depending on the number of samples in a shard, we may end up loading in a fair number of correlated samples. However, based on observation, only a few video sequences are included in a single shard.
* It's quite likely that the current set of parameters (e.g. max allowable number of instances in a frame) need to be tweaked.
* Documentation and code clean-up is still WIP.
* The branch is named `data-aug` but the augmentation routine has not been added yet. This will be addressed in a separate PR.