### PR TITLE
Fix training pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ matplotlib = [
  {version = ">=3.4", python = ">=3.7"}
 ]
 tqdm = "^4.60.0"
+simple-parsing = "^0.0.14"
+tensorboard = "^2.5.0"
 
 [build-system]
 requires = ["setuptools", "wheel", "poetry-core>=1.0.0"]

--- a/scripts/keypoint_regression.py
+++ b/scripts/keypoint_regression.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+from top.model.backbone import resnet_fpn_backbone
+from top.model.layers import KeypointRegressor2D
+from top.train.trainer import Trainer
+# from top.data.objectron_dataset_detection import Objectron
+
+
+def main():
+    pass

--- a/scripts/train_mnist.py
+++ b/scripts/train_mnist.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
+
+from dataclasses import dataclass
+from simple_parsing import Serializable
+
+import torch as th
+import torch.nn as nn
+import torch.nn.functional as F
+from torchvision import datasets, transforms
+from torch.utils.tensorboard import SummaryWriter
+
+from top.train.callback import (
+    Callbacks, EvalCallback, SaveModelCallback)
+from top.train.saver import Saver
+from top.train.trainer import Trainer
+
+from top.run.path_util import RunPath
+from top.run.torch_util import resolve_device
+
+
+@dataclass
+class AppSettings(Serializable):
+    device: str = ''
+    data_dir: str = '~/.cache/ai604/mnist/MNIST_data/'
+    batch_size: int = 32
+    train: Trainer.Settings = Trainer.Settings(num_epochs=4)
+    run: RunPath.Settings = RunPath.Settings(root='/tmp/mnist')
+
+
+class ConvBlock(nn.Module):
+    """ Simple Conv + BatnNorm + Relu block """
+
+    def __init__(self, c_in: int, c_out: int, k: int = 3, *args, **kwargs):
+        super().__init__()
+        # NOTE(ycho): bias=False since followed by BatchNorm anyway.
+        self.conv = nn.Conv2d(c_in, c_out, k, bias=False, *args, **kwargs)
+        self.bn = nn.BatchNorm2d(c_out)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = self.relu(x)
+        return x
+
+
+class Model(nn.Module):
+    """
+    Simple convolutional MNIST digit classification model.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = ConvBlock(1, 16)
+        self.conv2 = ConvBlock(16, 32, stride=2)
+        self.conv3 = ConvBlock(32, 64, stride=2)
+
+        # inference
+        self.flat = nn.Flatten()
+        self.fc = nn.Linear(1600, 10)
+
+    def forward(self, inputs):
+        x = inputs
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.flat(x)
+        x = self.fc(x)
+        return x
+
+
+def load_data(opts: AppSettings):
+    """ Fetch pair of (train,test) loaders for MNIST data """
+    # Configure loaders.
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+    train_dataset = datasets.MNIST(opts.data_dir, train=True, download=True,
+                                   transform=transform)
+    test_dataset = datasets.MNIST(opts.data_dir, train=False, download=False,
+                                  transform=transform)
+
+    train_loader = th.utils.data.DataLoader(
+        train_dataset, batch_size=opts.batch_size)
+    test_loader = th.utils.data.DataLoader(
+        test_dataset, batch_size=opts.batch_size)
+
+    return (train_loader, test_loader)
+
+
+class Evaluator:
+    """
+    Aggregate statistics over multiple batch and log statistics.
+    Currently only computes accuracy, potentially might be generalizable.
+    """
+
+    def __init__(self,
+                 writer: th.utils.tensorboard.SummaryWriter,
+                 device: th.device):
+        self.writer = writer
+        self.device = device
+
+        self.prev_step = None
+        self.num_samples = 0
+        self.num_correct = 0.0
+
+    def __call__(self, step: int, model: nn.Module, data):
+        # Logging at the end of aggregation loop.
+        if (step != self.prev_step):
+            if self.prev_step is not None:
+                # Log derived stat (accuracy).
+                print(F'Acc = {self.num_correct}/{self.num_samples}')
+                accuracy = (self.num_correct / self.num_samples)
+                print(F'@{step} accuracy={accuracy} ')
+                self.writer.add_scalar('accuracy', accuracy, step)
+
+            # Reset stats.
+            self.num_samples = 0
+            self.num_correct = 0.0
+            self.prev_step = step
+
+        # Run evaluation ...
+        inputs, target = data
+        inputs = inputs.to(self.device)
+        target = target.to(self.device)
+        output = model(inputs)
+
+        # Aggregate statistics.
+        num_correct = (target == th.argmax(output, dim=1)).sum()
+        self.num_samples += inputs.shape[0]
+        self.num_correct += num_correct
+
+
+def main():
+    # Settings ...
+    opts = AppSettings()
+
+    # Path configuration ...
+    path = RunPath(opts.run)
+
+    # Device resolution ...
+    device = resolve_device(opts.device)
+
+    # Data
+    train_loader, test_loader = load_data(opts)
+
+    # Model, loss
+    model = Model().to(device)
+    xs_loss = nn.CrossEntropyLoss()
+
+    def loss_fn(model: nn.Module, data):
+        inputs, target = data
+        inputs = inputs.to(device)
+        target = target.to(device)
+        output = model(inputs)
+        return xs_loss(output, target)
+
+    # Optimizer
+    optimizer = th.optim.Adam(model.parameters(), lr=1e-3)
+
+    # Callbacks, logging, ...
+    writer = th.utils.tensorboard.SummaryWriter(path.log)
+    evaluator = Evaluator(writer=writer, device=device)
+    callbacks = Callbacks([
+        EvalCallback(
+            EvalCallback.Settings(
+                num_samples=float('inf')
+            ), model, test_loader, eval_fn=evaluator)
+    ])
+
+    # Trainer
+    trainer = Trainer(
+        opts.train,
+        model,
+        optimizer,
+        loss_fn,
+        callbacks,
+        train_loader)
+
+    trainer.train()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/top/run/path_util.py
+++ b/src/top/run/path_util.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import logging
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -29,12 +30,13 @@ class RunPath(object):
     instead, we maintain a collision-free index based key
     for each experiment that we run and use them in a sub-folder structure.
     """
+
     @dataclass
     class Settings:
         key_format: str = 'run-{:03d}'
         root: str = '/tmp/'  # Alternatively, ~/.cache/ai604/run/
-        key: str = None
-
+        key: str = '' # Empty string indicates auto increment.
+ 
     def __init__(self, opts: Settings):
         self.opts = opts
         self.root = Path(opts.root).expanduser()
@@ -42,13 +44,13 @@ class RunPath(object):
 
         # Resolve sub-directory key.
         key = opts.key
-        if key is None:
+        if key is '':
             key = self._resolve_key(self.root, self.opts.key_format)
-            print(F'key={key}')
+            logging.info(F'key={key}')
 
         self.dir = self.root / key
         _ensure_directory(self.dir)
-        print(F'self.dir={self.dir}')
+        logging.info(F'self.dir={self.dir}')
 
     @staticmethod
     def _resolve_key(root: str, key_fmt: str) -> str:
@@ -79,9 +81,9 @@ def main():
     from tempfile import TemporaryDirectory
     with TemporaryDirectory() as tmpdir:
         rp = RunPath(RunPath.Settings(root=tmpdir))
-        print(rp.log)
+        logging.debug(rp.log)
         rp2 = RunPath(RunPath.Settings(root=tmpdir))
-        print(rp2.log)
+        logging.debug(rp2.log)
 
 
 if __name__ == '__main__':

--- a/src/top/run/torch_util.py
+++ b/src/top/run/torch_util.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import torch as th
+from typing import Union
+
+
+def resolve_device(device: Union[None, str, th.device]) -> th.device:
+    """ Resolve torch device based on user input. """
+    if device:
+        device = th.device(device)
+    else:
+        if th.cuda.is_available():
+            # NOTE(ycho): does NOT work for multi-gpu settings.
+            device = th.device('cuda:0')
+            th.cuda.set_device(device)
+        else:
+            device = th.device('cpu')
+    return device
+
+
+def main():
+    print(resolve_device(''))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/top/train/callback.py
+++ b/src/top/train/callback.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+from dataclasses import dataclass
+from typing import (Union, Callable, List, Dict, Tuple, Optional, Any)
+from pathlib import Path
+from simple_parsing import Serializable
+import torch as th
+import logging
+
+from top.train.saver import Saver
+
+
+class Callback(object):
+    """
+    Base class for periodic callbacks.
+    TODO(ycho): Consider migration to e.g. fast.ai API
+    when our custom solution cannot handle some sophisticated function.
+    """
+
+    def __init__(self, period: int, callback: Callable[[int], None]):
+        self.period = period
+        self.callback = callback
+        self.last_call = 0
+
+    def on_step(self, step: int):
+        # NOTE(ycho): Don't use (step % self.period) which is common,
+        # since if `num_env` != 0, lcm(period, num_env) may not be period.
+        if step < self.last_call + self.period:
+            return
+        self.callback(step)
+        self.last_call = step
+
+
+class SaveModelCallback(Callback):
+    """ Callback for saving models. """
+    @dataclass
+    class Settings(Serializable):
+        pattern: str = 'save-{:06d}.zip'
+        period: int = int(1e3)  # NOTE(ycho): by default, every 1000 steps
+
+    def __init__(self, opts: Settings, path: str, saver: Saver):
+        self.opts = opts
+        self.path = Path(path)
+        self.saver = saver
+        super().__init__(self.opts.period, self._save)
+
+    def _save(self, step: int):
+        filename = self.path / self.opts.pattern.format(step)
+        self.saver.save(filename)
+
+
+class EvalCallback(Callback):
+    """
+    Callback for periodic model evaluation.
+    Only sets up the boilerplate skeleton code, so `eval_fn` should do the heavy lifting.
+    The expected `eval` operations might include:
+
+    * computing relevant metrics (accuracy, recall, ...)
+    * logging the relevant metrics (to e.g. TensorBoard, Terminal, ...)
+    """
+
+    @dataclass
+    class Settings(Serializable):
+        period: int = int(1e3)
+        num_samples: int = 1
+
+    def __init__(self, opts: Settings, model: th.nn.Module,
+                 loader: th.utils.data.DataLoader, eval_fn=None):
+        self.opts = opts
+        self.model = model
+        self.loader = loader
+        self.eval_fn = eval_fn
+        super().__init__(self.opts.period, self._eval)
+
+    def _eval(self, step: int):
+        # NOTE(ycho): Set `model` to `eval` mode, but
+        # cache the previous model cfg for restoration.
+        prev_mode = self.model.training
+        self.model.eval()
+
+        # Run evaluation loop ...
+        count = 0
+        with th.no_grad():
+            for data in self.loader:
+                # Eval step...
+                self.eval_fn(step, self.model, data)
+
+                # Increment eval counts
+                count += 1
+                if count >= self.opts.num_samples:
+                    break
+
+        # NOTE(ycho): Restore previous training mode.
+        self.model.train(prev_mode)
+
+
+class Callbacks(Callback):
+    """
+    Class to sequentially process registered callbacks.
+    """
+
+    def __init__(self, callbacks: Optional[List[Callback]] = []):
+        self.callbacks = callbacks
+
+    def append(self, callback: Callback):
+        self.callbacks.append(callback)
+
+    def on_step(self, step: int):
+        for cb in self.callbacks:
+            cb.on_step(step)

--- a/src/top/train/saver.py
+++ b/src/top/train/saver.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from dataclasses import dataclass
+from typing import (Union, Callable, List, Dict, Tuple, Optional, Any)
+from pathlib import Path
+from simple_parsing import Serializable
+import torch as th
+import logging
+
+
+class Saver(object):
+
+    # Reserved keys
+    KEY_MODEL = '__model__'
+    KEY_OPTIM = '__optim__'
+
+    def __init__(self,
+                 model: th.nn.Module,
+                 optimizer: th.optim.Optimizer = None):
+        self.model = model
+        self.optim = optimizer
+
+    def load(self, path: str):
+        ckpt = th.load(path)
+
+        # Load parameters from the checkpoint ...
+        self.model.load_state_dict(ckpt.pop(self.KEY_MODEL))
+        if self.optim:
+            self.optim.load_state_dict(ckpt.pop(self.KEY_OPTIM))
+
+        # Any remainder will be returned.
+        return ckpt
+
+    def save(self, path: str, **kwargs):
+        # Model
+        save_dict = {self.KEY_MODEL: self.model.state_dict()}
+
+        # Optimizer
+        if self.optim is not None:
+            save_dict[self.KEY_OPTIM] = self.optim.state_dict()
+        else:
+            msg = F'Invalid optimizer={self.optim} on Saver.save()'
+            logging.warn(msg)
+
+        # Additional information
+        save_dict.update(kwargs)
+        th.save(save_dict, path)

--- a/src/top/train/trainer.py
+++ b/src/top/train/trainer.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+__all__ = ["Trainer"]
+
+from dataclasses import dataclass
+from typing import (Union, Callable, List, Dict, Tuple, Optional, Any)
+from pathlib import Path
+from simple_parsing import Serializable
+import torch as th
+import logging
+
+from top.train.callback import Callbacks
+from top.train.saver import Saver
+
+
+class Trainer(object):
+    """
+    Generic trainer for a pytorch nn.Module.
+    Intended to be flexible, modify as needed.
+    """
+
+    @dataclass
+    class Settings(Serializable):
+        train_steps: int = int(1e4)
+        eval_period: int = int(1e3)
+        num_epochs: int = int(1)
+
+    def __init__(self,
+                 opts: Settings,
+                 model: th.nn.Module,
+                 optimizer: th.optim.Optimizer,
+                 loss_fn: Callable[[th.nn.Module, Any], th.Tensor],
+                 callbacks: Callbacks,
+                 loader: th.utils.data.DataLoader
+                 ):
+        """
+        Args:
+            opts: Trainer options.
+            model: The model to train.
+            optimizer: Optimizer, e.g. `Adam`.
+            loss_fn: The function that maps (model, next(iter(loader))) -> cost.
+            callbacks: Callbacks to invoke during the training run.
+            loader: Iterable data loader.
+        """
+        self.opts = opts
+        self.model = model
+        self.optim = optimizer
+
+        # NOTE(ycho): loss_fn != th.nn.*Loss
+        # since it directly takes `model` as argument.
+        # This is (for now) intended to support maximum flexibility.
+        # The simplest such version might be something like:
+        # def loss_fn(model, data):
+        #     x, y = data
+        #     y_ = model(x)
+        #     return th.square(y_-y).mean()
+
+        self.loss_fn = loss_fn
+        self.callbacks = callbacks
+        self.loader = loader
+
+    def _train(self):
+        """
+        Internal function for dealing with the inner training loop.
+        """
+        step = 0
+        for epoch in range(self.opts.num_epochs):
+            # self.callbacks.on_epoch(epoch)
+            for i, data in enumerate(self.loader):
+                # Compute loss ...
+                # NOTE(ycho): if one of the callbacks require training loss,
+                # e.g. for logging, simply register a hook to the loss module
+                # rather than trying to extract them here.
+                loss = self.loss_fn(self.model, data)
+
+                # Backprop + Optimize ...
+                self.optim.zero_grad()
+                loss.backward()
+                self.optim.step()
+
+                # Deal with callbacks ...
+                # == logging, saving, evaluation
+                self.callbacks.on_step(step)
+                step += 1
+
+                if step >= self.opts.train_steps:
+                    return
+
+    def train(self):
+        self.model.train()
+
+        # TODO(ycho): Consider registering more hooks.
+        #self.callbacks.on_train(train)
+        try:
+            self._train()
+        except KeyboardInterrupt:
+            logging.info('Terminating training due to SIGINT')
+        finally:
+            # TODO(ycho): When an interrupt occurs, the current state
+            # will ALWAYS be saved to a hardcoded file in a temporary directory.
+            # Maybe this is a bad idea.
+            Saver(self.model, self.optim).save('/tmp/model-backup.zip')
+
+
+def main():
+    """ Simplest possible trainer setup """
+    model = th.nn.Linear(1, 1)
+    optim = th.optim.Adam(model.parameters(), lr=1e-3)
+
+    def loss_fn(model, data):
+        x, target = data
+        output = model(x)
+        loss = th.mean(th.square(output - target))
+        return loss
+
+    def get_loader():
+        while True:
+            # NOTE(ycho): `32` here is a dummy fictitious batch size.
+            x = th.empty((32, 1), dtype=th.float32)
+            y = th.empty((32, 1), dtype=th.float32)
+            yield (x, y)
+
+    trainer = Trainer(
+        Trainer.Settings(train_steps=1),
+        model,
+        optim,
+        loss_fn,
+        Callbacks(),
+        get_loader())
+
+    trainer.train()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
There were a number of issues with the previous version of the pipeline from #3 , which was as expected.
This PR updates the various framework related setup throughout the repository to make it at least work.
Only tested on the MNIST dataset (which is of course too easy)

Specifically, the current set of features are as follows:

* add dev dependencies to pyproject.toml
* (WIP) keypoint regression testing script
* add MNIST training example with our pipeline
* fix null-key issue with `RunPath`
* replace some `print` statements with `logging`
* add `torch_util` for torch-specific utilities
* split `train_util` into multiple files for readibility
* Fix aggregation issues with `EvalCallback`