### PR TITLE
Optional Mesh Rendering for ColoredCube

### DIFF
--- a/src/top/data/transforms/common.py
+++ b/src/top/data/transforms/common.py
@@ -38,7 +38,7 @@ class Normalize:
     class Settings(Serializable):
         mean: float = 0.5
         std: float = 0.25
-        in_place: bool = True
+        in_place: bool = False
         keys: Tuple[Schema, ...] = (Schema.IMAGE,)
 
     def __init__(self, opts: Settings):

--- a/src/top/model/layers.py
+++ b/src/top/model/layers.py
@@ -64,7 +64,7 @@ class EncoderBlock(nn.Module):
 class DisplacementLayer2D(nn.Module):
     @dataclass
     class Settings(Serializable):
-        hidden: Tuple[int] = ()
+        hidden: Tuple[int, ...] = ()
         # NOTE(ycho): 9 vertices by default, including centroid.
         num_keypoints: int = 9
 
@@ -101,7 +101,7 @@ class HeatmapLayer2D(nn.Module):
 
     @dataclass
     class Settings(Serializable):
-        hidden: Tuple[int] = ()
+        hidden: Tuple[int, ...] = ()
         num_class: int = 9
 
     def __init__(self, opts: Settings, c_in: int):


### PR DESCRIPTION
## Description

Since it was hard to tell whether or not the model was learning anything meaningful from the vertex-based (pointcloud) `ColoredCube` dataset, I added an option to render the dataset with the mesh faces instead which makes the problem significantly more difficult (while till manageable). A number of other random changes made its way into this PR (while testing keypoint regression network), but still remains relatively small.

## Changelog
* Add optional mesh rendering for coloredcube dataset
* Add Tensorboard graph logging
* Draw displacement maps for labels as well
* test_keypoint_transforms now uses standard loader
* debug: Normalize in_place false by default
* Fix signatures for hidden layer settings

## Results

Sample image:
![2021-05-10-image](https://user-images.githubusercontent.com/14655667/117611172-fa2a7380-b19d-11eb-86a6-689a4ff42470.png)

Tensorboard Graph:
![image](https://user-images.githubusercontent.com/14655667/117611228-15957e80-b19e-11eb-8c33-6dbd199311b7.png)
