### PR TITLE
Stabilize Keypoint Network Training

### DIFF
--- a/config/2021-05-12-cube-working-keypoint.yaml
+++ b/config/2021-05-12-cube-working-keypoint.yaml
@@ -1,0 +1,105 @@
+batch_size: 32
+dataset:
+  cache:
+    cache_dir: ~/.cache/ai604/
+    force_rebuild: false
+    num_samples: 8
+  cube:
+    aspect: 1.0
+    batch_size: 32
+    fov: 60
+    image_size:
+    - 256
+    - 256
+    max_distance: 10.0
+    min_distance: 0.1
+    unstack: true
+    use_mesh: true
+    zfar: 100.0
+    znear: 0.1
+  dataset: CUBE
+  num_workers: 0
+  objectron:
+    bucket_name: objectron
+    classes:
+    - bike
+    - book
+    - bottle
+    - camera
+    - cereal_box
+    - chair
+    - cup
+    - laptop
+    - shoe
+    context:
+    - count
+    - sequence_id
+    features:
+    - instance_num
+    - image/width
+    - image/height
+    - image/channels
+    - image/encoded
+    - object/name
+    - object/translation
+    - object/orientation
+    - object/scale
+    - point_3d
+    - point_2d
+    - point_num
+    - camera/intrinsics
+    - camera/projection
+    shuffle_shards: true
+  shuffle: false
+  use_cached_dataset: false
+device: ''
+eval_period: 1000
+log_period: 32
+maps:
+  downsample: 4
+  in_place: true
+  kernel_size: 9
+  num_class: 1
+  sigma: 3.0
+  use_displacement: false
+model:
+  backbone_name: resnet50
+  center:
+    hidden:
+    - 128
+    num_class: 1
+  keypoint:
+    heatmap:
+      hidden:
+      - 128
+      num_class: 9
+    kernel_size: 3
+    num_keypoints: 9
+  num_trainable_layers: 0
+  returned_layers:
+  - 4
+  soft_sigmoid_eps: 0.0001
+  upsample:
+    kernel_size: 4
+  upsample_steps:
+  - 128
+  - 64
+  - 16
+padding:
+  max_num_inst: 1
+  pad_keys:
+  - point_2d
+  - point_3d
+  - object/translation
+  - object/orientation
+  - object/scale
+  - object/class
+  - point_num
+path:
+  key: ''
+  key_format: run-{:03d}
+  root: /tmp/ai604-kpt
+save_period: 1000
+train:
+  num_epochs: 8
+  train_steps: 10000

--- a/config/2021-05-12-objectron-overfit-test.yaml
+++ b/config/2021-05-12-objectron-overfit-test.yaml
@@ -1,0 +1,105 @@
+batch_size: 8
+dataset:
+  cache:
+    cache_dir: ~/.cache/ai604/
+    force_rebuild: false
+    num_samples: 8
+  cube:
+    aspect: 1.0
+    batch_size: 1
+    fov: 60
+    image_size:
+    - 256
+    - 256
+    max_distance: 10.0
+    min_distance: 0.1
+    unstack: true
+    use_mesh: true
+    zfar: 100.0
+    znear: 0.1
+  dataset: OBJECTRON
+  num_workers: 0
+  objectron:
+    bucket_name: objectron
+    classes:
+    - bike
+    - book
+    - bottle
+    - camera
+    - cereal_box
+    - chair
+    - cup
+    - laptop
+    - shoe
+    context:
+    - count
+    - sequence_id
+    features:
+    - instance_num
+    - image/width
+    - image/height
+    - image/channels
+    - image/encoded
+    - object/name
+    - object/translation
+    - object/orientation
+    - object/scale
+    - point_3d
+    - point_2d
+    - point_num
+    - camera/intrinsics
+    - camera/projection
+    shuffle_shards: true
+  shuffle: false
+  use_cached_dataset: true
+device: ''
+eval_period: 1000
+log_period: 32
+maps:
+  downsample: 4
+  in_place: true
+  kernel_size: 9
+  num_class: 9
+  sigma: 3.0
+  use_displacement: false
+model:
+  backbone_name: resnet50
+  center:
+    hidden:
+    - 128
+    num_class: 9
+  keypoint:
+    heatmap:
+      hidden:
+      - 128
+      num_class: 9
+    kernel_size: 3
+    num_keypoints: 9
+  num_trainable_layers: 0
+  returned_layers:
+  - 4
+  soft_sigmoid_eps: 0.0001
+  upsample:
+    kernel_size: 4
+  upsample_steps:
+  - 128
+  - 64
+  - 16
+padding:
+  max_num_inst: 4
+  pad_keys:
+  - point_2d
+  - point_3d
+  - object/translation
+  - object/orientation
+  - object/scale
+  - object/class
+  - point_num
+path:
+  key: ''
+  key_format: run-{:03d}
+  root: /tmp/ai604-kpt
+save_period: 1000
+train:
+  num_epochs: 1
+  train_steps: 10000

--- a/src/top/data/colored_cube_dataset.py
+++ b/src/top/data/colored_cube_dataset.py
@@ -38,10 +38,8 @@ from top.data.schema import Schema
 
 
 class ColoredCubeDataset(th.utils.data.IterableDataset):
-    """
-    Toy generative dataset for 3D object detection:
-    vertices of an oriented unit cube rendered as a point cloud.
-    Intended to be an "easy" baseline.
+    """Toy generative dataset for 3D object detection: vertices of an oriented
+    unit cube rendered as a point cloud. Intended to be an "easy" baseline.
 
     # FIXME(ycho): I realized that the cube length is actually 2
     """
@@ -138,9 +136,8 @@ class ColoredCubeDataset(th.utils.data.IterableDataset):
         return renderer
 
     def _get_cube_cloud(self):
-        """
-        Get vertices of a unit-cube, with colors assigned according to vertex coordinates.
-        """
+        """Get vertices of a unit-cube, with colors assigned according to
+        vertex coordinates."""
         vertices = list(itertools.product(
             *zip([-0.5, -0.5, -0.5], [0.5, 0.5, 0.5])))
         vertices = np.insert(vertices, 0, [0, 0, 0], axis=0)
@@ -187,10 +184,10 @@ class ColoredCubeDataset(th.utils.data.IterableDataset):
         return mesh
 
     def _render(self):
-        """
-        Render the unit cube at various camera poses.
-        We deliberately sample the camera poses such that all vertices of the cube
-        are always in view.
+        """Render the unit cube at various camera poses.
+
+        We deliberately sample the camera poses such that all vertices
+        of the cube are always in view.
         """
         opts = self.opts
 
@@ -304,7 +301,7 @@ class ColoredCubeDataset(th.utils.data.IterableDataset):
                 Schema.INSTANCE_NUM: th.ones(
                     self.opts.batch_size,
                     device=self.device),
-                Schema.PROJECTION: projection,
+                Schema.PROJECTION: projection.repeat(self.opts.batch_size, 1, 1),
             }
 
             # Unstack the batched render into a set of images, for compatibility with Objectron.
@@ -322,12 +319,13 @@ class ColoredCubeDataset(th.utils.data.IterableDataset):
 
 
 def main():
-    opts = ColoredCubeDataset.Settings(batch_size=4)
+    opts = ColoredCubeDataset.Settings(batch_size=32, unstack = False)
     opts = update_settings(opts)
 
     device = resolve_device()
     dataset = ColoredCubeDataset(opts, device,)
     for data in dataset:
+        print({k:v.shape for k,v in data.items()})
         save_image(data[Schema.IMAGE] / 255.0, F'/tmp/img.png')
         break
 

--- a/src/top/data/load.py
+++ b/src/top/data/load.py
@@ -58,9 +58,8 @@ def get_dataset(opts: DatasetSettings, train: bool,
         dataset = ColoredCubeDataset(opts.cube, device, transform)
     elif opts.dataset == DatasetOptions.OBJECTRON:
         # NOTE(ycho): Ignores `device` argument.
-        data_opts = opts.objectron
-        data_opts = replace(data_opts, train=train)
-        dataset = ObjectronDetection(data_opts, transform)
+        dataset = ObjectronDetection(
+            opts.objectron, train=train, transform=transform)
     else:
         raise ValueError(F'Invalid dataset choice : {opts.dataset} not found!')
     return dataset

--- a/src/top/data/objectron_detection.py
+++ b/src/top/data/objectron_detection.py
@@ -87,8 +87,7 @@ class ObjectronDetection(th.utils.data.IterableDataset):
             'cup',
             'laptop',
             'shoe')
-        train: bool = True
-        shuffle: bool = True
+        shuffle_shards: bool = True
         # NOTE(ycho): Refer to objectron/schema/features.py
         context: Tuple[str, ...] = ('count', 'sequence_id')
         # NOTE(ycho): Refer to objectron/schema/features.py
@@ -111,8 +110,9 @@ class ObjectronDetection(th.utils.data.IterableDataset):
         )
         cache_dir = '~/.cache/ai604/'
 
-    def __init__(self, opts: Settings, transform=None):
+    def __init__(self, opts: Settings, train: bool = True, transform=None):
         self.opts = opts
+        self.train = train
         self.shards = self._get_shards()
         self.xfm = transform
 
@@ -131,7 +131,7 @@ class ObjectronDetection(th.utils.data.IterableDataset):
 
     def _get_shards(self):
         """ return list of shards, potentially memoized for efficiency """
-        prefix = 'train' if self.opts.train else 'test'
+        prefix = 'train' if self.train else 'test'
         # FIXME(ycho): hardcoded {prefix}-det-shards
         shards_cache = F'{self.opts.cache_dir}/{prefix}-det-shards.pkl'
 
@@ -145,12 +145,12 @@ class ObjectronDetection(th.utils.data.IterableDataset):
             with open(str(shards_path), 'rb') as f:
                 shards = pickle.load(f)
 
-        if self.opts.shuffle:
+        if self.opts.shuffle_shards:
             np.random.shuffle(shards)
         return shards
 
     def _glob(self) -> List[str]:
-        train_type = 'train' if self.opts.train else 'test'
+        train_type = 'train' if self.train else 'test'
         shards = []
 
         # Aggregate class shards

--- a/src/top/data/schema.py
+++ b/src/top/data/schema.py
@@ -7,8 +7,8 @@ from simple_parsing.helpers.serialization import encode, register_decoding_fn
 
 
 class Schema(Enum):
-    """
-    Set of fixed constants to refer to contents from our dataset interfaces.
+    """Set of fixed constants to refer to contents from our dataset interfaces.
+
     NOTE(ycho): Generally intended to follow the Objectron schema.
     """
     IMAGE = "image"
@@ -24,18 +24,20 @@ class Schema(Enum):
     HEATMAP = "object/heatmap"
     HEATMAP_LOGITS = "object/heatmap_logits"
     DISPLACEMENT_MAP = "displacement_map"
+    KEYPOINT_HEATMAP = "keypoint_heatmap"
     KEYPOINT_NUM = "point_num"
     VISIBILITY = "visibility"
+    KEYPOINT_OFFSET = "keypoint_offset"
 
 
 @encode.register(Schema)
 def encode_schema(obj: Schema) -> str:
-    """Encode the enum with the underlying `str` representation. """
+    """Encode the enum with the underlying `str` representation."""
     return str(obj.value)
 
 
 def decode_schema(obj: str) -> Schema:
-    """ Decode str into Schema enum """
+    """Decode str into Schema enum."""
     return Schema(obj)
 
 

--- a/src/top/model/keypoint.py
+++ b/src/top/model/keypoint.py
@@ -15,22 +15,32 @@ from top.model.layers import (
 from top.data.schema import Schema
 
 
+def _in_place_clipped_sigmoid(x: th.Tensor, eps: float):
+    """Clipped in-place sigmoid in range [eps,1-eps].
+
+    # NOTE(ycho): Adopted soft sigmoid from CenterNet Repo
+    """
+    return th.clamp(x.sigmoid_(), eps, 1.0 - eps)
+
+    # return x.sigmoid_().clip_(eps, 1.0 - eps)
+
+
 class KeypointNetwork2D(nn.Module):
-    """
-    Simple 2D Keypoint inference network.
-    """
+    """Simple 2D Keypoint inference network."""
 
     @dataclass
     class Settings(Serializable):
         backbone_name: str = 'resnet50'
         num_trainable_layers: int = 0
-        # keypoint: KeypointLayer2D.Settings = KeypointLayer2D.Settings()
         returned_layers: Tuple[int, ...] = (4,)
         upsample: ConvUpsample.Settings = ConvUpsample.Settings()
-        displacement: DisplacementLayer2D.Settings = DisplacementLayer2D.Settings()
-        heatmap: HeatmapLayer2D.Settings = HeatmapLayer2D.Settings()
+        # displacement: DisplacementLayer2D.Settings = DisplacementLayer2D.Settings()
+        center: HeatmapLayer2D.Settings = HeatmapLayer2D.Settings()
+        keypoint: KeypointLayer2D.Settings = KeypointLayer2D.Settings()
         # NOTE(ycho): upsample_steps < 5 results in downsampling.
         upsample_steps: Tuple[int, ...] = (128, 64, 16)
+
+        clip_sigmoid_eps: float = 1e-4  # soft sigmoid epsilon
 
     def __init__(self, opts: Settings):
         super().__init__()
@@ -52,9 +62,9 @@ class KeypointNetwork2D(nn.Module):
 
         self.upsample = nn.Sequential(*upsample_layers)
 
-        self.heatmap = HeatmapLayer2D(opts.heatmap, c_in=c_in)
-        # self.keypoint = KeypointLayer2D(opts.keypoint, c_in=16)
-        self.displacement = DisplacementLayer2D(opts.displacement, c_in=c_in)
+        self.center = HeatmapLayer2D(opts.center, c_in=c_in)
+        self.keypoint = KeypointLayer2D(opts.keypoint, c_in=c_in)
+        # self.displacement = DisplacementLayer2D(opts.displacement, c_in=c_in)
 
     def forward(self, inputs):
         x = inputs
@@ -66,11 +76,23 @@ class KeypointNetwork2D(nn.Module):
         x = self.upsample(x)
 
         # Final outputs ...
-        heatmap = self.heatmap(x)
-        displacement_map = self.displacement(x)
+        center_logits = self.center(x)
+
+        center = _in_place_clipped_sigmoid(center_logits,
+                                           self.opts.clip_sigmoid_eps)
+
+        # displacement_map = self.displacement(x)
+        kpt_offset, kpt_heatmap = self.keypoint(x)
+
+        kpt_heatmap = _in_place_clipped_sigmoid(kpt_heatmap,
+                                                self.opts.clip_sigmoid_eps)
+
         output = {
-            Schema.HEATMAP_LOGITS: heatmap,
-            Schema.DISPLACEMENT_MAP: displacement_map
+            Schema.HEATMAP: center,
+            # Schema.HEATMAP_LOGITS: heatmap_logits,
+            # Schema.DISPLACEMENT_MAP: displacement_map
+            Schema.KEYPOINT_OFFSET: kpt_offset,
+            Schema.KEYPOINT_HEATMAP: kpt_heatmap
         }
         return output
 
@@ -79,8 +101,7 @@ def main():
     model = KeypointNetwork2D(KeypointNetwork2D.Settings())
     dummy = th.empty((1, 3, 128, 128), dtype=th.float32)
     out = model(dummy)
-    print(out[Schema.DISPLACEMENT_MAP].shape)
-    print(out[Schema.HEATMAP_LOGITS].shape)
+    print(out[Schema.HEATMAP].shape)
 
 
 if __name__ == '__main__':

--- a/src/top/model/loss.py
+++ b/src/top/model/loss.py
@@ -8,23 +8,43 @@ from typing import Dict
 
 from top.data.schema import Schema
 
+from top.model.loss_util import FocalLoss
+
 
 class ObjectHeatmapLoss(nn.Module):
-    def __init__(self):
+    def __init__(self, key: Schema = Schema.HEATMAP):
         super().__init__()
-        self.loss = nn.MSELoss()
+        self.focal_loss = FocalLoss()
+        self.key = key
 
     def forward(
             self, output: Dict[str, th.Tensor],
-            target: Dict[str, th.Tensor]) -> float:
-        if Schema.HEATMAP in output:
-            pred = output[Schema.HEATMAP]
-        elif Schema.HEATMAP_LOGITS in output:
-            pred = th.sigmoid(output[Schema.HEATMAP_LOGITS])
-        else:
-            raise KeyError(
-                F'Could not find heatmap key in {list(output.keys())}')
-        return self.loss(pred, target[Schema.HEATMAP])
+            targets: Dict[str, th.Tensor]) -> float:
+
+        # Extract relevant tensors from arguments.
+        pred = output[self.key]
+        target = targets[self.key]
+
+        # FIXME(ycho): Hardcoded batch_size inference
+        batch_size = target.shape[0]
+
+        # NOTE(ycho): deprecated for now ...
+        if False:
+            diff = pred - target
+            mask = th.ones_like(diff, dtype=th.bool)
+            # Ignore padded labels after `num_instance`.
+            #inums = target[Schema.INSTANCE_NUM]
+            #for batch_i in range(batch_size):
+            #    num_instance = inums[batch_i]
+            #    mask[batch_i, num_instance:] = False
+
+            diff[~mask] = 0.0
+            numer = th.sum(th.square(diff))
+            denom = th.sum(mask)
+            return numer / denom
+
+        out = self.focal_loss(pred, target)
+        return out
 
 
 class KeypointDisplacementLoss(nn.Module):
@@ -34,10 +54,13 @@ class KeypointDisplacementLoss(nn.Module):
     def forward(self, output: Dict[str, th.Tensor],
                 target: Dict[str, th.Tensor]) -> float:
         pred = output[Schema.DISPLACEMENT_MAP]
+
         mask = th.isfinite(target[Schema.DISPLACEMENT_MAP])
+
         diff = pred - target[Schema.DISPLACEMENT_MAP]
         # NOTE(ycho): during inference, this mask is approximated
         # by the heatmaps.
+        # NOTE(ycho): We MUST this use form since inf * 0 = NaN.
         diff[~mask] = 0.0
         # NOTE(ycho): Using abs here, which results in L1 loss.
         numer = th.sum(th.abs(diff))
@@ -45,10 +68,20 @@ class KeypointDisplacementLoss(nn.Module):
         return numer / denom
 
 
+class KeypointHeatmapLoss(nn.Module):
+    def __init__(self):
+        return NotImplemented
+
+    def forward(
+            self, output: Dict[str, th.Tensor],
+            target: Dict[str, th.Tensor]) -> float:
+        return NotImplemented
+
+
 class KeypointCrossEntropyLoss(nn.Module):
-    """
-    Given a keypoint heatmap of logits,
-    compute the loss against integer-valued target map of keypoints.
+    """Given a keypoint heatmap of logits, compute the loss against integer-
+    valued target map of keypoints.
+
     TODO(ycho): Perhaps not the best idea, especially if the number of keypoints are very sparse.
     """
 

--- a/src/top/model/loss_util.py
+++ b/src/top/model/loss_util.py
@@ -1,5 +1,5 @@
-"""
-Util classes & methods for computing loss.
+"""Util classes & methods for computing loss.
+
 Reference: https://github.com/xingyizhou/CenterNet/blob/master/src/lib/models/losses.py
 """
 
@@ -10,14 +10,15 @@ import torch.nn.functional as F
 
 
 def _gather_feat(feat, ind, mask=None):
-    dim  = feat.size(2)
-    ind  = ind.unsqueeze(2).expand(ind.size(0), ind.size(1), dim)
+    dim = feat.size(2)
+    ind = ind.unsqueeze(2).expand(ind.size(0), ind.size(1), dim)
     feat = feat.gather(1, ind)
     if mask is not None:
         mask = mask.unsqueeze(2).expand_as(feat)
         feat = feat[mask]
         feat = feat.view(-1, dim)
     return feat
+
 
 def _transpose_and_gather_feat(feat, ind):
     feat = feat.permute(0, 2, 3, 1).contiguous()
@@ -26,9 +27,9 @@ def _transpose_and_gather_feat(feat, ind):
     return feat
 
 
-def _neg_loss(pred, gt):
-    """
-    Focal loss same as CornerNet.
+def _neg_loss(pred: th.Tensor, gt: th.Tensor):
+    """Focal loss same as CornerNet.
+
     Args:
         pred (batch x c x h x w)
         gt_regr (batch x c x h x w)
@@ -43,7 +44,7 @@ def _neg_loss(pred, gt):
     pos_loss = th.log(pred) * th.pow(1 - pred, 2) * pos_inds
     neg_loss = th.log(1 - pred) * th.pow(pred, 2) * neg_weights * neg_inds
 
-    num_pos  = pos_inds.float().sum()
+    num_pos = pos_inds.float().sum()
     pos_loss = pos_loss.sum()
     neg_loss = neg_loss.sum()
 
@@ -51,8 +52,9 @@ def _neg_loss(pred, gt):
         loss = loss - neg_loss
     else:
         loss = loss - (pos_loss + neg_loss) / num_pos
-    
+
     return loss
+
 
 def _reg_loss(regr, gt_regr, mask):
     """
@@ -67,10 +69,10 @@ def _reg_loss(regr, gt_regr, mask):
 
     regr = regr * mask
     gt_regr = gt_regr * mask
-    
+
     regr_loss = nn.functional.smooth_l1_loss(regr, gt_regr, size_average=False)
     regr_loss = regr_loss / (num + 1e-4)
-    
+
     return regr_loss
 
 
@@ -89,29 +91,34 @@ def orientation_loss(tri_orient_batch, tri_orientGT_batch, confGT_batch):
     tri_orientGT_batch = tri_orientGT_batch[th.arange(batch_size), indexes]
     tri_orient_batch = tri_orient_batch[th.arange(batch_size), indexes]
 
-    theta_diff = th.atan2(tri_orientGT_batch[:,1], tri_orientGT_batch[:,0])
-    estimated_theta_diff = th.atan2(tri_orient_batch[:,1], tri_orient_batch[:,0])
+    theta_diff = th.atan2(tri_orientGT_batch[:, 1], tri_orientGT_batch[:, 0])
+    estimated_theta_diff = th.atan2(
+        tri_orient_batch[:, 1],
+        tri_orient_batch[:, 0])
 
     return -1 * th.cos(theta_diff - estimated_theta_diff).mean()
+
 
 def generate_bins(bins):
     angle_bins = np.zeros(bins)
     interval = 2 * np.pi / bins
-    for i in range(1,bins):
+    for i in range(1, bins):
         angle_bins[i] = i * interval
-    angle_bins += interval / 2 # center of the bin
+    angle_bins += interval / 2  # center of the bin
 
     return angle_bins
 
 
 class FocalLoss(nn.Module):
-    """nn.Module warpper for focal loss"""
+    """nn.Module warpper for focal loss."""
+
     def __init__(self):
         super(FocalLoss, self).__init__()
         self.neg_loss = _neg_loss
 
     def forward(self, out, target):
         return self.neg_loss(out, target)
+
 
 class RegLoss(nn.Module):
     """
@@ -122,10 +129,22 @@ class RegLoss(nn.Module):
         ind (batch x max_objects)
         target (batch x max_objects x dim)
     """
+
     def __init__(self):
         super(RegLoss, self).__init__()
-  
+
     def forward(self, output, mask, ind, target):
         pred = _transpose_and_gather_feat(output, ind)
         loss = _reg_loss(pred, target, mask)
         return loss
+
+
+def main():
+    focal_loss = FocalLoss()
+    pred = th.zeros(size=(3, 4, 5))
+    target = th.zeros(size=(3, 4, 5))
+    print(focal_loss(pred, target))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description

After a set of architectural changes the keypoint network (at least the heatmap portion) that largely takes after the style of `CenterNet` is working quite well. I think the key factors are the incorporation of `FocalLoss` and the conversion of the displacement-map inference to a heatmap based inference. I have validated the current architecture against the `ColoredCube` dataset, strategizing to see how we could adapt this for `ObjectronDetection`.

## Changelog

* Add configuration for stable keypoint training
* Generalized keypoint rendering
* Better visualizations accounting for classes
* Data preprocessing temporarily on the GPU (for cube dataset)
* Some settings params were renamed.
* Added some comments here and there.
* Soft sigmoid instead of hard sigmoids (like `CenterNet`)
* Added but disabled instance-wise masking (not needed for now)

## Results
See [folder](https://drive.google.com/drive/folders/1naB8H0jMcefkOW09h_xIs4AiIC2rexld)