### PR TITLE
Crop objects to train 3D bounding box regression

### DIFF
--- a/scripts/bb_regression.py
+++ b/scripts/bb_regression.py
@@ -43,11 +43,14 @@ class AppSettings(Serializable):
     dataset: DatasetSettings = DatasetSettings()
     padding: InstancePadding.Settings = InstancePadding.Settings()
     path: RunPath.Settings = RunPath.Settings(root='/tmp/ai604-kpt')
-    train: Trainer.Settings = Trainer.Settings(train_steps=1, eval_period=1)
+    train: Trainer.Settings = Trainer.Settings(train_steps=1)
     # FIXME(Jiyong): need to test padding for batch
     batch_size: int = 1
     alpha: float = 0.5
     device: str = 'cpu'
+    log_period: int = 32
+    save_period:int = 100
+    eval_period:int = 100
 
 
 class TrainLogger:

--- a/scripts/bb_regression.py
+++ b/scripts/bb_regression.py
@@ -157,6 +157,7 @@ def main():
     # TODO(ycho): Consider folding this callback inside Trainer()
     # and adding {test_loader, eval_fn} args to Trainer instead.
     def _eval_fn(model, data):
+        # TODO(Jiyong): hardcode for cropped image size
         crop_img = data[Schema.CROPPED_IMAGE].view(-1, 3, 224, 224)
         return model(crop_img.to(device))
     evaluator = Evaluator(
@@ -199,16 +200,9 @@ def main():
         # loss = opts.alpha * scale_loss + orient_loss
         
         dim, quat = model(image)
-        print('...')
-        print(image.max())
-        print(truth_dim.max())
-        print(truth_orient.max())
-        print(dim.max())
-        print(quat.max())
+
         scale_loss = scale_loss_func(dim, truth_dim)
-        print(scale_loss)
         orient_loss = orientation_loss_func(quat, truth_orient)
-        print(orient_loss)
         loss = opts.alpha * scale_loss + orient_loss
 
         return loss

--- a/scripts/bb_regression.py
+++ b/scripts/bb_regression.py
@@ -9,22 +9,27 @@ Reference:
 
 from dataclasses import dataclass, replace
 from simple_parsing import Serializable
+from typing import Dict, Any
+from tqdm.auto import tqdm
 
 import torch as th
 import torch.nn as nn
+from torch.utils.tensorboard import SummaryWriter
 from torchvision.transforms import Compose
 
 from top.train.trainer import Trainer
-from top.train.callback import Callbacks, EvalCallback, SaveModelCallback
+from top.train.trainer import Saver
+from top.train.event.hub import Hub
+from top.train.event.topics import Topic
+from top.train.event.helpers import (Collect, Periodic, Evaluator)
 
 from top.run.app_util import update_settings
 from top.run.path_util import RunPath
 from top.run.torch_util import resolve_device
 
 from top.model.bbox_3d import BoundingBoxRegressionModel
-from top.model.loss_util import orientation_loss, generate_bins
 
-from top.data.objectron_detection import Objectron
+from top.data.load import (DatasetSettings, get_loaders)
 from top.data.schema import Schema
 from top.data.bbox_reg_util import CropObject, ClassAverages
 
@@ -32,7 +37,10 @@ from top.data.bbox_reg_util import CropObject, ClassAverages
 @dataclass
 class AppSettings(Serializable):
     model: BoundingBoxRegressionModel.Settings = BoundingBoxRegressionModel.Settings()
-    dataset: Objectron.Settings = Objectron.Settings()
+    
+    # Dataset selection options.
+    dataset: DatasetSettings = DatasetSettings()
+    
     path: RunPath.Settings = RunPath.Settings(root='/tmp/ai604-kpt')
     train: Trainer.Settings = Trainer.Settings(train_steps=1, eval_period=1)
     # FIXME(Jiyong): need to test padding for batch
@@ -41,26 +49,50 @@ class AppSettings(Serializable):
     device: str = 'cpu'
 
 
-def load_data(opts: AppSettings, device: th.device):
-    # TODO(Jiyong): change data preprocessing for ClassAverage of dimesion.
-    # Currently, regress dimension directly(not residual)
-    transform = Compose([CropObject(CropObject.Settings())])
-    data_opts = opts.dataset
+class TrainLogger:
+    """
+    Logging during training - specifically, tqdm-based logging to the shell and tensorboard.
+    """
+    def __init__(self, hub: Hub, writer: SummaryWriter, period: int):
+        self.step = None
+        self.hub = hub
+        self.writer = writer
+        self.tqdm = tqdm()
+        self.period = period
+        self._subscribe()
 
-    # For train data
-    data_opts = replace(data_opts, train=True)
-    train_dataset = Objectron(data_opts, transform)
-    # For test data
-    data_opts = replace(data_opts, train=False)
-    test_dataset = Objectron(data_opts, transform)
+    def _on_loss(self, loss):
+        """log training loss."""
+        loss = loss.detach().cpu()
 
-    train_loader = th.utils.data.DataLoader(
-        train_dataset, batch_size=opts.batch_size)
-    test_loader = th.utils.data.DataLoader(
-        test_dataset, batch_size=opts.batch_size)
+        # Update tensorboard ...
+        self.writer.add_scalar('train_loss', loss, global_step=self.step)
 
-    return train_loader, test_loader
+        # update tqdm logger bar.
+        self.tqdm.set_postfix(loss=loss)
+        self.tqdm.update()
 
+    def _on_train_out(self, inputs, outputs):
+        """log tranining outputs."""
+        # Fetch inputs ...
+        with th.no_grad():
+            input_image = (inputs(Schema.IMAGE).detach())
+        
+        self.writer.add_image('train_images', input_image[0].cpu(), global_step=self.step)
+
+    def _on_step(self, step):
+        """save current step"""
+        self.step = step
+    
+    def _subscribe(self):
+        self.hub.subscribe(Topic.STEP, self._on_step)
+        # NOTE(ycho): Log loss only periodically.
+        self.hub.subscribe(Topic.TRAIN_LOSS, Periodic(self.period, self._on_loss))
+        self.hub.subscribe(Topic.TRAIN_OUT, Periodic(self.period, self._on_train_out))
+    
+    def __del__(self):
+        self.tqdm.close()
+               
 
 def main():
 
@@ -71,18 +103,78 @@ def main():
     device = resolve_device(opts.device)
     model = BoundingBoxRegressionModel(opts.model).to(device)
     optimizer = th.optim.Adam(model.parameters(), lr=1e-3)
+    writer = SummaryWriter(path.log)
 
-    train_loader, test_loader = load_data(opts, device=device)
+    transform = Compose([CropObject(CropObject.Settings())])
+    train_loader, test_loader = get_loaders(opts.dataset,
+                                            device=th.device('cpu'),
+                                            batch_size=opts.batch_size,
+                                            transform=transform)
 
-    callbacks = Callbacks([])
+    # NOTE(ycho): Synchronous event hub.
+    hub = Hub()
 
-    # NOTE(Jiyong): for MultiBin method
-    # conf_loss_func = nn.CrossEntropyLoss().to(device)
-    # orient_loss_func = orientation_loss
+    # Save meta-parameters.
+    def _save_params():
+        opts.save(path.dir / 'opts.yaml')
+    hub.subscribe(Topic.TRAIN_BEGIN, _save_params)
+
+    # Periodically log training statistics.
+    # FIXME(ycho): hardcoded logging period.
+    # NOTE(ycho): Currently only plots `loss`.
+    collect = Collect(hub, Topic.METRICS, [])
+    train_logger = TrainLogger(hub, writer, opts.log_period)
+
+    # Periodically save model, per epoch.
+    # TODO(ycho): Consider folding this callback inside Trainer().
+    hub.subscribe(
+        Topic.EPOCH,
+        lambda epoch: Saver(
+            model,
+            optimizer).save(
+            path.ckpt /
+            F'epoch-{epoch}.zip'))
+
+    # Periodically save model, per N training steps.
+    # TODO(ycho): Consider folding this callback inside Trainer()
+    # and adding {save_period} args to Trainer instead.
+    hub.subscribe(
+        Topic.STEP,
+        Periodic(opts.save_period, lambda step: Saver(
+            model,
+            optimizer).save(
+            path.ckpt /
+            F'step-{step}.zip')))
+
+    # Periodically evaluate model, per N training steps.
+    # NOTE(ycho): Load and process test data ...
+    # TODO(ycho): Consider folding this callback inside Trainer()
+    # and adding {test_loader, eval_fn} args to Trainer instead.
+    def _eval_fn(model, data):
+        return model(data[Schema.IMAGE].to(device))
+    evaluator = Evaluator(
+        Evaluator.Settings(period=opts.eval_period),
+        hub, model, test_loader, _eval_fn)
+
+    # TODO(Jiyong):
+    # All metrics evaluation should reset stats at eval_begin(),
+    # aggregate stats at eval_step(),
+    # and output stats at eval_end(). These signals are all implemented.
+    # What are the appropriate metrics to implement for bounding box regression?
+    def _on_eval_step(inputs, outputs):
+        pass
+    hub.subscribe(Topic.EVAL_STEP, _on_eval_step)
+
+    collect = Collect(hub, Topic.METRICS, [])
+
+    def _log_all(metrics: Dict[Topic, Any]):
+        pass
+    hub.subscribe(Topic.METRICS, _log_all)
+
     orientation_loss_func = nn.MSELoss().to(device)
     scale_loss_func = nn.MSELoss().to(device)
 
-    def loss_fn(model: th.nn.Module, data):
+    def _loss_fn(model: th.nn.Module, data):
         # Now that we're here, convert all inputs to the device.
         image = data[Schema.CROPPED_IMAGE]
         truth_orient = data[Schema.ORIENTATION]
@@ -92,9 +184,6 @@ def main():
         num_obj = len(image)
         loss = 0
         for i in range(num_obj):
-            # TODO(Jiyong): need to fix error("ValueError: only one element
-            # tensors can be converted to Python scalars") for trying
-            # to(device) at above.
             _image = image[i].to(device)
             _truth_orient = th.squeeze(truth_orient[i]).to(device)
             _truth_dim = th.squeeze(truth_dim[i]).to(device)
@@ -102,7 +191,7 @@ def main():
             dim, quat = model(_image)
 
             scale_loss = scale_loss_func(dim, _truth_dim)
-            orient_loss = orientation_loss(quat, _truth_orient)
+            orient_loss = orientation_loss_func(quat, _truth_orient)
 
             loss += opts.alpha * scale_loss + orient_loss
 
@@ -111,8 +200,8 @@ def main():
     trainer = Trainer(opts.train,
                       model,
                       optimizer,
-                      loss_fn,
-                      callbacks,
+                      _loss_fn,
+                      hub,
                       train_loader)
 
     print('======Training Start======')

--- a/src/top/data/bbox_reg_util.py
+++ b/src/top/data/bbox_reg_util.py
@@ -115,19 +115,13 @@ class CropObject(object):
         translation = th.as_tensor(translation)
         translation = translation.reshape(-1,3)
 
-        x_min, y_min, _ = th.min(keypoints_2d, dim=1).values
-        x_max, y_max, _ = th.max(keypoints_2d, dim=1).values
+        point_min = th.min(keypoints_2d, dim=1).values
+        point_max = th.max(keypoints_2d, dim=1).values
         
-        crop_img = th.empty(num_object, self.opts.crop_img_size, self.opts.crop_img_size)
+        crop_img = th.empty(num_object, self.opts.crop_img_size[0], self.opts.crop_img_size[1])
         for obj in range(num_object):
-            crop_tmp = image[:, y_min[obj]:y_max[obj], x_min[obj]:x_max[obj]]
-            crop_tmp = th.transpose(crop_tmp, (1,2,0))
-            try:
-                crop_tmp = F.interpolate(crop_tmp, dsize=self.opts.crop_img_size)
-            except Exception as e:
-                print(crop_tmp.shape)
-                raise
-            crop_tmp = th.transpose(crop_tmp, (2,0,1))
+            crop_tmp = image[:, int(point_min[obj][1]):int(point_max[obj][1]), int(point_min[obj][0]):int(point_max[obj][0])]
+            crop_tmp = F.interpolate(crop_tmp, size=self.opts.crop_img_size[0])
             crop_img[obj] = crop_tmp
 
         # shallow copy
@@ -140,3 +134,5 @@ class CropObject(object):
         # print([(k, v.shape) if isinstance(v, th.Tensor) else (k,v) for k,v in outputs.items()])
 
         return outputs
+
+# FIXME(Jiyong): split class -> crop / resize(built-in) / collate_fn

--- a/src/top/data/bbox_reg_util.py
+++ b/src/top/data/bbox_reg_util.py
@@ -14,10 +14,13 @@ from simple_parsing import Serializable
 
 import torch as th
 import torch.nn.functional as F
+from torchvision.transforms.functional import resize
 from pytorch3d.transforms import matrix_to_quaternion
 
 from top.data.schema import Schema
 from top.run.box_generator import Box
+
+import pickle
 
 """
 Enables writing json with numpy arrays to file
@@ -118,10 +121,10 @@ class CropObject(object):
         point_min = th.min(keypoints_2d, dim=1).values
         point_max = th.max(keypoints_2d, dim=1).values
         
-        crop_img = th.empty(num_object, self.opts.crop_img_size[0], self.opts.crop_img_size[1])
+        crop_img = th.empty(num_object, 3, self.opts.crop_img_size[0], self.opts.crop_img_size[1])
         for obj in range(num_object):
             crop_tmp = image[:, int(point_min[obj][1]):int(point_max[obj][1]), int(point_min[obj][0]):int(point_max[obj][0])]
-            crop_tmp = F.interpolate(crop_tmp, size=self.opts.crop_img_size[0])
+            crop_tmp = resize(crop_tmp, size=self.opts.crop_img_size)
             crop_img[obj] = crop_tmp
 
         # shallow copy
@@ -134,5 +137,3 @@ class CropObject(object):
         # print([(k, v.shape) if isinstance(v, th.Tensor) else (k,v) for k,v in outputs.items()])
 
         return outputs
-
-# FIXME(Jiyong): split class -> crop / resize(built-in) / collate_fn

--- a/src/top/data/bbox_reg_util.py
+++ b/src/top/data/bbox_reg_util.py
@@ -130,6 +130,7 @@ class CropObject(object):
         keypoint_2d_min = th.min(keypoints_2d_clamp, dim=1).values
         keypoint_2d_max = th.max(keypoints_2d_clamp, dim=1).values
         
+        # TODO(Jiyong): change tensor to list -> append -> change dtype
         vis_crop_img = th.tensor([])
         vis_point_2d = th.tensor([])
         vis_trans = th.tensor([])

--- a/src/top/data/colored_cube_dataset.py
+++ b/src/top/data/colored_cube_dataset.py
@@ -14,24 +14,19 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torchvision.utils import save_image
 
-from pytorch3d.io import load_objs_as_meshes
-from pytorch3d.structures import Pointclouds, Meshes
-from pytorch3d.transforms.transform3d import Transform3d
-from pytorch3d.renderer import (
-    look_at_view_transform,
-    FoVPerspectiveCameras,
-    PointsRasterizationSettings,
-    PointsRenderer,
-    PointsRasterizer,
-    MeshRenderer,
-    MeshRasterizer,
-    RasterizationSettings,
-    SoftPhongShader,
-    PointLights,
-    AlphaCompositor,
-    TexturesVertex
-)
-
+try:
+    from pytorch3d.structures import Pointclouds
+    from pytorch3d.transforms.transform3d import Transform3d
+    from pytorch3d.renderer import (
+        look_at_view_transform,
+        FoVPerspectiveCameras,
+        PointsRasterizationSettings,
+        PointsRenderer,
+        PointsRasterizer,
+        AlphaCompositor,
+    )
+except ImportError:
+    print('welp')
 from top.run.torch_util import resolve_device
 from top.run.app_util import update_settings
 from top.data.schema import Schema

--- a/src/top/data/colored_cube_dataset.py
+++ b/src/top/data/colored_cube_dataset.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 #PYTHON_ARGCOMPLETE_OK
 
-import pkg_resources
 
+import logging
 import itertools
 from dataclasses import dataclass
 from simple_parsing import Serializable
@@ -26,7 +26,7 @@ try:
         AlphaCompositor,
     )
 except ImportError:
-    print('welp')
+    logging.warn('pytorch3d import has failed, colored cube dataset will be disabled.')
 from top.run.torch_util import resolve_device
 from top.run.app_util import update_settings
 from top.data.schema import Schema

--- a/src/top/data/load.py
+++ b/src/top/data/load.py
@@ -6,11 +6,13 @@ from simple_parsing import Serializable
 # NOTE(ycho): Required for dealing with `enum` registration
 from simple_parsing.helpers.serialization import encode, register_decoding_fn
 import torch as th
-from top.data.colored_cube_dataset import ColoredCubeDataset
 
+from top.data.colored_cube_dataset import ColoredCubeDataset
 from top.data.objectron_sequence import ObjectronSequence
 from top.data.objectron_detection import ObjectronDetection
 from top.data.cached_dataset import CachedDataset
+
+from collections import defaultdict
 
 
 # TODO(ycho): add objectron sequence as an option.
@@ -66,7 +68,7 @@ def get_dataset(opts: DatasetSettings, train: bool,
 
 
 def get_loaders(opts: DatasetSettings, device: th.device,
-                batch_size: int, transform=None):
+                batch_size: int, transform=None, collate_fn=None):
     """ Fetch pair of (train,test) loaders for MNIST data """
 
     if opts.use_cached_dataset:
@@ -88,12 +90,27 @@ def get_loaders(opts: DatasetSettings, device: th.device,
         train_dataset,
         batch_size=batch_size,
         shuffle=opts.shuffle,
-        num_workers=opts.num_workers)
+        num_workers=opts.num_workers,
+        collate_fn=collate_fn)
 
     test_loader = th.utils.data.DataLoader(
         test_dataset,
         batch_size=batch_size,
         shuffle=opts.shuffle,
-        num_workers=opts.num_workers)
+        num_workers=opts.num_workers,
+        collate_fn=collate_fn)
 
     return (train_loader, test_loader)
+
+
+def collate_cropped_img(data):
+    out = defaultdict(list)
+    for d in data:
+        [out[k].append(v) for k,v in d.items()]
+    
+    for k in out:
+        v = out[k]
+        if len(v)>0 and isinstance(v[0], th.Tensor):
+            out[k] = th.cat(v, dim=0)
+    
+    return out

--- a/src/top/data/load.py
+++ b/src/top/data/load.py
@@ -6,8 +6,8 @@ from simple_parsing import Serializable
 # NOTE(ycho): Required for dealing with `enum` registration
 from simple_parsing.helpers.serialization import encode, register_decoding_fn
 import torch as th
-
 from top.data.colored_cube_dataset import ColoredCubeDataset
+
 from top.data.objectron_sequence import ObjectronSequence
 from top.data.objectron_detection import ObjectronDetection
 from top.data.cached_dataset import CachedDataset

--- a/src/top/data/objectron_detection.py
+++ b/src/top/data/objectron_detection.py
@@ -61,7 +61,7 @@ def decode(example, feature_names: List[str] = []):
         Schema.SCALE: scale,
         Schema.PROJECTION: example['camera/projection'],
         Schema.KEYPOINT_NUM: num_keypoints,
-        Schema.VISIBILITY: visibility,
+        Schema.VISIBILITY: visibility
     }
 
     out.update({k: example[k] for k in feature_names})
@@ -107,6 +107,7 @@ class ObjectronDetection(th.utils.data.IterableDataset):
             'point_num',
             'camera/intrinsics',
             'camera/projection',
+            'object/visibility'
         )
         cache_dir = '~/.cache/ai604/'
 

--- a/src/top/data/schema.py
+++ b/src/top/data/schema.py
@@ -26,8 +26,7 @@ class Schema(Enum):
     DISPLACEMENT_MAP = "displacement_map"
     KEYPOINT_HEATMAP = "keypoint_heatmap"
     KEYPOINT_NUM = "point_num"
-    VISIBILITY = "visibility"
-    KEYPOINT_OFFSET = "keypoint_offset"
+    CROPPED_IMAGE = "crop_img"
 
 
 @encode.register(Schema)

--- a/src/top/data/schema.py
+++ b/src/top/data/schema.py
@@ -28,6 +28,7 @@ class Schema(Enum):
     KEYPOINT_NUM = "point_num"
     CROPPED_IMAGE = "crop_img"
     VISIBILITY = "object/visibility"
+    QUATERNION = "quaternion"
 
 
 @encode.register(Schema)

--- a/src/top/data/schema.py
+++ b/src/top/data/schema.py
@@ -27,6 +27,7 @@ class Schema(Enum):
     KEYPOINT_HEATMAP = "keypoint_heatmap"
     KEYPOINT_NUM = "point_num"
     CROPPED_IMAGE = "crop_img"
+    VISIBILITY = "object/visibility"
 
 
 @encode.register(Schema)

--- a/src/top/data/transforms/common.py
+++ b/src/top/data/transforms/common.py
@@ -78,7 +78,7 @@ class InstancePadding:
             # Schema.KEYPOINT_MAP,
             # Schema.DISPLACEMENT_MAP,
             Schema.KEYPOINT_NUM,  # I guess this is needed too...
-            Schema.VISIBILITY
+            Schema.CROPPED_IMAGE
         )
 
     def __init__(self, opts: Settings):

--- a/src/top/model/bbox_3d.py
+++ b/src/top/model/bbox_3d.py
@@ -56,10 +56,10 @@ class BoundingBoxRegressionModel(nn.Module):
                     nn.Flatten(),
                     nn.Linear(256 * 7 * 7, 256),
                     nn.ReLU(True),
-                    nn.Dropout(),
+                    # nn.Dropout(),
                     nn.Linear(256, 256),
                     nn.ReLU(True),
-                    nn.Dropout(),
+                    # nn.Dropout(),
                     nn.Linear(256, 4)
                 )
 
@@ -68,10 +68,10 @@ class BoundingBoxRegressionModel(nn.Module):
                     nn.Flatten(),
                     nn.Linear(256 * 7 * 7, 256),
                     nn.ReLU(True),
-                    nn.Dropout(),
+                    # nn.Dropout(),
                     nn.Linear(256, 256),
                     nn.ReLU(True),
-                    nn.Dropout(),
+                    # nn.Dropout(),
                     nn.Linear(256, 3)
                 )
 


### PR DESCRIPTION
This PR is about cropping objects from original image to make able to parallelize.

Except for invisible objects, cropping was performed on the rest of the objects.
For the following annotations, make outputs except for invisible objects.

Also, change logging methods from callbacks to event hub
change framework numpy and scipy to pytorch

After cropping, outputs shape is as follow:
Schema.IMAGE = [num_visible_object, 3, 480, 640]
Schema.CROPPED_IMAGE = [num_visible_object, 3, 224, 224]
Schema.KEYPOINT_2D = [num_visible_object, 9, 3]
Schema.TRANSLATION = [num_visible_object, 3]
Schema.ORIENTATION = [num_visible_object, 4] # change rotation matrix to quaternions
Schema.SCALE = [num_visible_object, 3]