### PR TITLE
Overhaul sequence data loading

### DIFF
--- a/scripts/test_keypoint_transforms.py
+++ b/scripts/test_keypoint_transforms.py
@@ -12,7 +12,7 @@ from top.data.load import (DatasetSettings, get_loaders)
 from top.data.objectron_detection import ObjectronDetection, SampleObjectron
 from top.data.colored_cube_dataset import ColoredCubeDataset
 from top.data.transforms import (
-    BoxHeatmap,
+    BoxPoints2D,
     DrawKeypoints,
     DrawKeypointMap,
     DenseMapsMobilePose,
@@ -35,35 +35,23 @@ def main():
 
     device = resolve_device('cpu')
 
-    xfm = Compose([BoxHeatmap(device=device),
-                   DrawKeypoints(DrawKeypoints.Settings()),
-                   DenseMapsMobilePose(DenseMapsMobilePose.Settings(), device),
-                   InstancePadding(InstancePadding.Settings()),
-                   #DrawDisplacementMap(DrawDisplacementMap.Settings(
-                   #    key_in=Schema.DISPLACEMENT_MAP,
-                   #    key_out='dmap_vis'
-                   #))
-                   ])
+    xfm = Compose([
+        BoxPoints2D(device=device),
+        DrawKeypoints(DrawKeypoints.Settings()),
+        DenseMapsMobilePose(DenseMapsMobilePose.Settings(), device),
+        InstancePadding(InstancePadding.Settings()),
+    ])
 
     dataset, _ = get_loaders(opts.dataset, device, None, xfm)
 
     for data in dataset:
+        print(data['points_2d_debug'])
+        print(data[Schema.KEYPOINT_2D])
         save_image(data[Schema.IMAGE] / 255.0, F'/tmp/img.png')
-        # save_image(data['rendered_keypoints'] / 255.0, F'/tmp/rkpts.png')
-
-        for i, img in enumerate(data[Schema.KEYPOINT_MAP]):
-            save_image(img / 255.0, F'/tmp/kpt-{i}.png')
-
         for i, img in enumerate(data[Schema.HEATMAP]):
             save_image(img, F'/tmp/heatmap-{i}.png',
                        normalize=True)
 
-        #for i, img in enumerate(data[Schema.DISPLACEMENT_MAP]):
-        #    save_image(
-        #        th.where(th.isfinite(img), img.abs(), th.as_tensor(0.0)),
-        #        F'/tmp/displacement-{i}.png',
-        #        normalize=True)
-        # save_image(data['dmap_vis'], '/tmp/dmap-vis.png')
         break
 
 

--- a/src/top/data/cached_dataset.py
+++ b/src/top/data/cached_dataset.py
@@ -37,7 +37,9 @@ class CachedDataset(th.utils.data.IterableDataset):
             # Download data from scratch ...
             dataset = self.dataset_fn()
             samples = []
-            for i, data in tqdm(enumerate(dataset)):
+            for i, data in tqdm(
+                    enumerate(dataset),
+                    total=self.opts.num_samples):
                 samples.append(data)
                 if i >= self.opts.num_samples:
                     break

--- a/src/top/data/objectron_detection.py
+++ b/src/top/data/objectron_detection.py
@@ -64,8 +64,8 @@ def decode(example, feature_names: List[str] = []):
         Schema.ORIENTATION: th.as_tensor(orientation),
         Schema.SCALE: th.as_tensor(scale),
         Schema.PROJECTION: th.as_tensor(example['camera/projection']),
-        Schema.KEYPOINT_NUM: num_keypoints,
-        Schema.VISIBILITY: visibility,
+        Schema.KEYPOINT_NUM: th.as_tensor(num_keypoints),
+        Schema.VISIBILITY: th.as_tensor(visibility),
         Schema.CLASS: bytes(example['object/name']).decode(),
         Schema.INTRINSIC_MATRIX: th.as_tensor(example['camera/intrinsics'])
     }

--- a/src/top/data/transforms/sequence.py
+++ b/src/top/data/transforms/sequence.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-"""
-Set of transforms related to sequences.
-"""
+"""Set of transforms related to sequences."""
 
-__all__ = ['DecodeImage', 'ParseFixedLength']
+__all__ = ['CropSequence']
 
 import itertools
 from dataclasses import dataclass
@@ -14,49 +12,14 @@ import numpy as np
 import torch as th
 import torch.nn as nn
 import torch.nn.functional as F
+import torchvision.io as thio
+from torchvision import transforms
 
 from top.data.schema import Schema
 
 
-class DecodeImage:
-    """
-    Decode serialized image bytes, and resize them to a fixed size.
-    FIXME(ycho): Modify camera intrinsics according to the resize transform.
-    """
-
-    def __init__(self, size: Tuple[int, int], in_place: bool = True):
-        self.size = size
-        self.in_place = in_place
-        self.resize = transforms.Resize(self.size)
-
-    def __call__(self, inputs: Tuple[dict, dict]):
-        if inputs is None:
-            return None
-        context, features = inputs
-
-        # NOTE(ycho): Shallow copy but pedantically safer
-        if not self.in_place:
-            features = features.copy()
-
-        # Replace `image/encoded` with `image`
-        features['image'] = th.stack([
-            self.resize(thio.decode_image(th.from_numpy(img_bytes)))
-            for img_bytes in features['image/encoded']], dim=0)
-
-        del features['image/encoded']
-
-        # Dimension features are no longer valid.
-        # We can also rewrite them, but this information is already
-        # implicitly included in features["image"].
-        del features['image/width']
-        del features['image/height']
-
-        return (context, features)
-
-
-class ParseFixedLength:
-    """
-    Convert variable-length sequence to fixed-length representation.
+class CropSequence:
+    """Convert variable-length sequence to fixed-length representation.
     Intended to be used immediately after the raw output from `Objectron`.
 
     FIXME(ycho): Isn't it a bit wasteful to slice up a full video once
@@ -71,22 +34,29 @@ class ParseFixedLength:
 
         # NOTE(ycho): Variable-length fields to apply padding for
         # `max_num_inst` ... needed for collating to batch
-        pad_keys: Tuple[str, ...] = (
-            'object/translation', 'object/orientation', 'object/scale')
+        pad_keys: Tuple[Schema, ...] = (
+            Schema.IMAGE,
+            Schema.KEYPOINT_2D,
+            Schema.INSTANCE_NUM,
+            Schema.TRANSLATION,
+            Schema.ORIENTATION,
+            Schema.SCALE,
+            Schema.PROJECTION,
+            Schema.KEYPOINT_NUM,
+            Schema.VISIBILITY,
+            Schema.CLASS,
+            Schema.INTRINSIC_MATRIX
+        )
 
     def __init__(self, opts: Settings):
         self.opts = opts
 
-    def __call__(
-            self, inputs: Tuple[Dict[str, th.Tensor],
-                                Dict[str, th.Tensor]]):
+    def __call__(self, inputs: Dict[Hashable, th.Tensor]):
         if inputs is None:
             return None
-        context, features = inputs
 
         # Reject data with less than `seq_len` frames.
-        # NOTE(ycho): Unsqueeze `count` which is a scalar.
-        n = context['count'][0]
+        n = inputs[Schema.IMAGE].shape[0]
         if n < self.opts.seq_len:
             return None
 
@@ -98,37 +68,6 @@ class ParseFixedLength:
         i0 = np.random.randint(0, n - strided_len + 1)
         i1 = i0 + strided_len
 
-        # FIXME(ycho):
-        # sequence_id is currently a bytes list instead of `string`.
-        # This makes it somewhat clunky to collate, so we'll drop this field
-        # for now.
-        # TODO(ycho): Consider adding `stride` to `new_ctx`
-        new_ctx = dict(count=self.opts.seq_len)
-        new_feat = {k: v[i0:i1:stride] for (k, v) in features.items()}
-
-        # Some property are variable-length, since they are dependent on `instance_num`.
-        # Pad the sequences to account for this.
-        for key in self.opts.pad_keys:
-            num_inst = new_feat['instance_num']
-            x = new_feat[key]
-
-            # single reference instance
-            ref = th.as_tensor(x[0])
-            # Compute single-feature dimension
-            # TODO(ycho): consider assert for ref.shape[0] % num_inst[0] == 0
-            dim = int(ref.shape[0] // num_inst[0])
-
-            x_pad = ref.new_empty(
-                (self.opts.seq_len, dim * self.opts.max_num_inst))
-            if np.all(num_inst == num_inst[0]):
-                # TODO(ycho): ensure this still works if
-                # `instance_num` > `max_num_inst`
-                m = min(dim * self.opts.max_num_inst, ref.shape[0])
-                x_pad[:, :m] = th.as_tensor(x)[:, :m]
-            else:
-                max_n = min(self.opts.max_num_inst, num_ints)
-                for i, n in enumerate(max_n):
-                    x_pad[i, :n * dim] = th.as_tensor(x[i])
-            new_feat[key] = x_pad
-
-        return (new_ctx, new_feat)
+        outputs = {k: (v[i0:i1:stride] if isinstance(v, th.Tensor) else v)
+                   for (k, v) in inputs.items()}
+        return outputs


### PR DESCRIPTION
## Description

Fix the sequence data loading so that we can finally actually use `ObjectronSequence` dataset.

## Changelog
* Refactor useless BoxHeatmap into point projection utility
* Refactor BoxPoints2D to use vectorized operations
* Add additional th.as_tensor() wrappers where necessary
* Fix type annotations for ObjectronSequence Settings
* Deprecate DecodeImage
* Upgrade instancepadding to accept generic axis arguments
* Reduce ParseFixedLength into CropSequence
* Collation actually works for sequence data, format (BTC...)

## Results
```
$ python3 objectron_sequence.py
# ...
{<Schema.IMAGE: 'image'>: torch.Size([8, 8, 3, 640, 480]), <Schema.KEYPOINT_2D: 'point_2d'>: torch.Size([8, 8, 4, 27]), <Schema.INSTANCE_NUM: 'instance_num'>: torch.Size([8, 8, 1]), <Schema.TRANSLATION: '
object/translation'>: torch.Size([8, 8, 4, 3]), <Schema.ORIENTATION: 'object/orientation'>: torch.Size([8, 8, 4, 9]), <Schema.SCALE: 'object/scale'>: torch.Size([8, 8, 4, 3]), <Schema.PROJECTION: 'camera/
projection'>: torch.Size([8, 8, 16]), <Schema.KEYPOINT_NUM: 'point_num'>: torch.Size([8, 8, 4]), <Schema.VISIBILITY: 'object/visibility'>: torch.Size([8, 8, 4, 1]), <Schema.CLASS: 'object/class'>: torch.S
ize([8, 8, 4, 1]), <Schema.INTRINSIC_MATRIX: 'camera/intrinsics'>: torch.Size([8, 8, 9])}
```